### PR TITLE
Follow committee v2

### DIFF
--- a/committee-rails.gemspec
+++ b/committee-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_dependency 'committee', '< 2.0.0'
+  spec.add_dependency 'committee', '~> 2.0.0.pre6'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'actionpack'
   spec.add_dependency 'railties'

--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -6,21 +6,43 @@ module Committee::Rails
       def schema_path
         Rails.root.join('docs', 'schema', 'schema.json')
       end
-
       def assert_schema_conform
-        if (data = schema_contents).is_a?(String)
-          warn_string_deprecated
-          data = JSON.parse(data)
+        @committee_schema ||= begin
+          # The preferred option. The user has already parsed a schema elsewhere
+          # and we therefore don't have to worry about any performance
+          # implications of having to do it for every single test suite.
+          if committee_schema
+            committee_schema
+          else
+            schema = schema_contents
+
+            if schema.is_a?(String)
+              warn_string_deprecated
+            elsif schema.is_a?(Hash)
+              warn_hash_deprecated
+            end
+
+            if schema.is_a?(String)
+              schema = JSON.parse(schema)
+            end
+
+            if schema.is_a?(Hash) || schema.is_a?(JsonSchema::Schema)
+              driver = Committee::Drivers::HyperSchema.new
+
+              # The driver itself has its own special cases to be able to parse
+              # either a hash or JsonSchema::Schema object.
+              schema = driver.parse(schema)
+            end
+
+            schema
+          end
         end
 
-        @schema ||= begin
-          schema = JsonSchema.parse!(data)
-          schema.expand_references!
-          schema
-        end
-        @router ||= Committee::Router.new(@schema, prefix: schema_url_prefix)
+        @committee_router ||= Committee::Router.new(@committee_schema,
+          prefix: schema_url_prefix)
 
-        unless link = @router.find_request_link(request)
+        link, _ = @committee_router.find_request_link(request)
+        unless link
           invalid_response = "`#{request.request_method} #{request.path_info}` undefined in schema."
           raise Committee::InvalidResponse.new(invalid_response)
         end

--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -3,9 +3,14 @@ module Committee::Rails
     module Methods
       include Committee::Test::Methods
 
-      def schema_path
-        Rails.root.join('docs', 'schema', 'schema.json')
+      def committee_schema
+        @committee_schema ||= begin
+          driver = Committee::Drivers::HyperSchema.new
+          schema_hash = JSON.parse(File.read(Rails.root.join('docs', 'schema', 'schema.json')))
+          driver.parse(schema_hash)
+        end
       end
+
       def assert_schema_conform
         @committee_schema ||= begin
           # The preferred option. The user has already parsed a schema elsewhere

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -3,8 +3,12 @@ require 'spec_helper'
 describe '#assert_schema_conform', type: :request do
   include Committee::Rails::Test::Methods
 
-  def schema_path
-    Rails.root.join('schema', 'schema.json')
+  def committee_schema
+    @committee_schema ||= begin
+      driver = Committee::Drivers::HyperSchema.new
+      schema_hash = JSON.parse(File.read(Rails.root.join('schema', 'schema.json')))
+      driver.parse(schema_hash)
+    end
   end
 
   context 'response conform JSON Schema' do


### PR DESCRIPTION
I'm working with upgrading this library to follow committee v2.
In this PR I made two changes.

## Fix assert_schema_conform method
Just Copy-and-paste new code of committee and fix as same as current way.

## Override committee_schema method instead of schema_path

Overriding schema_path is now deprecated.
https://github.com/interagent/committee/blob/26e811050dabd83cb8b3ccf4b13695ef45452852/lib/committee/test/methods.rb#L67-L69
Instead I used committee_schema method.