### PR TITLE
`rake spec` is correct?

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ describe 'request spec' do
 
   def schema_path
     Rails.root.join('path', 'to', 'schema.json') # default to docs/schema/schema.json
-  end  
+  end
 
   describe 'GET /' do
     it 'conform json schema' do


### PR DESCRIPTION
`rake test`  command is in README but I couldn't run it. It seems that `rake spec` is a command for running tests, right? I fixed the README.