### PR TITLE
Use schema options

### DIFF
--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -5,10 +5,18 @@ module Committee::Rails
 
       def committee_schema
         @committee_schema ||= begin
+          schema = committee_options[:schema]
+
+          return schema if schema
+
           driver = Committee::Drivers::HyperSchema.new
           schema_hash = JSON.parse(File.read(Rails.root.join('docs', 'schema', 'schema.json')))
           driver.parse(schema_hash)
         end
+      end
+
+      def committee_options
+        {}
       end
 
       def assert_schema_conform

--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -4,10 +4,9 @@ module Committee::Rails
       include Committee::Test::Methods
 
       def committee_schema
-        @committee_schema ||= begin
-          schema = committee_options[:schema]
+        @committee_schema = committee_options[:schema]
 
-          return schema if schema
+        @committee_schema ||= begin
 
           driver = Committee::Drivers::HyperSchema.new
           schema_hash = JSON.parse(File.read(Rails.root.join('docs', 'schema', 'schema.json')))


### PR DESCRIPTION
From committee 3.0, committee will remove `committee_schema` method.
https://github.com/interagent/committee/blob/master/lib/committee/test/methods.rb#L63
https://github.com/interagent/committee#change-test-assertions

Perhaps users will overwrite `committee_options` method when they want to change schema_path instead of `committee_schema`.

This PR make `committee_schema` changeable by overwriting `committee_options`, with backward compatibilities.