### PR TITLE
support committee new options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-before_install: gem install bundler
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/README.md
+++ b/README.md
@@ -24,16 +24,14 @@ If you use committee prior to 2.0, you have to use committee-rails 0.1.x. Please
 
 ## Usage
 
+### normal usage
+
 ```ruby
 describe 'request spec' do
   include Committee::Rails::Test::Methods
 
-  def committee_schema
-    @committee_schema ||= begin
-      driver = Committee::Drivers::HyperSchema.new
-      schema_hash = JSON.parse(File.read(Rails.root.join('schema', 'schema.json'))) # default to docs/schema/schema.json
-      driver.parse(schema_hash)
-    end
+  def committee_options
+    @committee_options ||= { schema_path: Rails.root.join('schema', 'schema.json').to_s }
   end
 
   describe 'GET /' do
@@ -42,6 +40,16 @@ describe 'request spec' do
       assert_schema_conform
     end
   end
+end
+```
+
+### rspec setting
+If you use rspec, you can use very simple.
+
+```ruby
+RSpec.configure do |config|
+  config.add_setting :committee_options
+  config.committee_options = { schema_path: Rails.root.join('schema', 'schema.json').to_s }
 end
 ```
 

--- a/committee-rails.gemspec
+++ b/committee-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_dependency 'committee', '>= 2.0.0'
+  spec.add_dependency 'committee', '>= 2.4.0'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'actionpack'
   spec.add_dependency 'railties'

--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -4,65 +4,32 @@ module Committee::Rails
       include Committee::Test::Methods
 
       def committee_schema
-        @committee_schema = committee_options[:schema]
-
-        @committee_schema ||= begin
-
-          driver = Committee::Drivers::HyperSchema.new
-          schema_hash = JSON.parse(File.read(Rails.root.join('docs', 'schema', 'schema.json')))
-          driver.parse(schema_hash)
-        end
+        # this code for 2.4.0, committee 3.x use committee_options
+        @committee_schema ||= Committee::Middleware::Base.new(nil, committee_options).send(:get_schema, committee_options)
       end
 
       def committee_options
-        {}
+        if defined?(RSpec) && (options = RSpec.try(:configuration).try(:committee_options))
+          options
+        elsif !defined?(@committee_schema)
+          { schema: default_schema }
+        else
+          # schema_url_prefix method call this but the user overrite comittee_schema, we got error
+          # we can remove in comittee 3.x
+          { schema: committee_schema }
+        end
       end
 
-      def assert_schema_conform
-        @committee_schema ||= begin
-          # The preferred option. The user has already parsed a schema elsewhere
-          # and we therefore don't have to worry about any performance
-          # implications of having to do it for every single test suite.
-          if committee_schema
-            committee_schema
-          else
-            schema = schema_contents
+      def default_schema
+        @default_schema ||= Committee::Drivers.load_from_file(Rails.root.join('docs', 'schema', 'schema.json').to_s)
+      end
 
-            if schema.is_a?(String)
-              warn_string_deprecated
-            elsif schema.is_a?(Hash)
-              warn_hash_deprecated
-            end
+      def request_object
+        request
+      end
 
-            if schema.is_a?(String)
-              schema = JSON.parse(schema)
-            end
-
-            if schema.is_a?(Hash) || schema.is_a?(JsonSchema::Schema)
-              driver = Committee::Drivers::HyperSchema.new
-
-              # The driver itself has its own special cases to be able to parse
-              # either a hash or JsonSchema::Schema object.
-              schema = driver.parse(schema)
-            end
-
-            schema
-          end
-        end
-
-        @committee_router ||= Committee::Router.new(@committee_schema,
-          prefix: schema_url_prefix)
-
-        link, _ = @committee_router.find_request_link(request)
-        unless link
-          invalid_response = "`#{request.request_method} #{request.path_info}` undefined in schema."
-          raise Committee::InvalidResponse.new(invalid_response)
-        end
-
-        if validate_response?(response.response_code)
-          data = JSON.parse(response.body)
-          Committee::ResponseValidator.new(link).call(response.response_code, response.headers, data)
-        end
+      def response_data
+        [response.status, response.headers, response.body]
       end
     end
   end

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -3,25 +3,59 @@ require 'spec_helper'
 describe '#assert_schema_conform', type: :request do
   include Committee::Rails::Test::Methods
 
-  def committee_schema
-    @committee_schema ||= begin
-      driver = Committee::Drivers::HyperSchema.new
-      schema_hash = JSON.parse(File.read(Rails.root.join('schema', 'schema.json')))
-      driver.parse(schema_hash)
+  context 'set option' do
+    before do
+      RSpec.configuration.add_setting :committee_options
+      RSpec.configuration.committee_options = {schema_path: Rails.root.join('schema', 'schema.json').to_s }
+    end
+
+    context 'response conform JSON Schema' do
+      it 'pass' do
+        post '/users', params: { nickname: 'willnet' }
+        assert_schema_conform
+      end
+    end
+
+    context "response doesn't conform JSON Schema" do
+      it 'fail' do
+        patch '/users/1', params: { nickname: 'willnet' }
+        expect { assert_schema_conform }.to raise_error(Committee::InvalidResponse)
+      end
     end
   end
 
-  context 'response conform JSON Schema' do
-    it 'pass' do
-      post '/users', params: { nickname: 'willnet' }
-      assert_schema_conform
-    end
-  end
+  context 'not set option' do
+    context 'not override default setting' do
+      before do
+        RSpec.configuration.committee_options = nil
+      end
 
-  context "response doesn't conform JSON Schema" do
-    it 'fail' do
-      patch '/users/1', params: { nickname: 'willnet' }
-      expect { assert_schema_conform }.to raise_error(Committee::InvalidResponse)
+      it 'use default setting' do
+        post '/users', params: { nickname: 'willnet' }
+        expect{ assert_schema_conform }.to raise_error(Errno::ENOENT) # not exist doc/schema/schema.json
+      end
+    end
+
+    context 'override default setting' do
+      def committee_schema
+        @committee_schema ||= Committee::Drivers.load_from_file(Rails.root.join('schema', 'schema.json').to_s)
+      end
+
+      it 'pass' do
+        post '/users', params: { nickname: 'willnet' }
+        assert_schema_conform
+      end
+    end
+
+    context 'override default setting' do
+      def committee_options
+        {schema_path: Rails.root.join('schema', 'schema.json').to_s }
+      end
+
+      it 'pass' do
+        post '/users', params: { nickname: 'willnet' }
+        assert_schema_conform
+      end
     end
   end
 end


### PR DESCRIPTION
Now we'll big change in committee 3.x.
In 3.x we most set data by `committee_options`.

And we add migration changes in committee 2.4.0 so we should use it.  
https://github.com/interagent/committee#change-test-assertions