### PR TITLE
Add missing require for "committee"

### DIFF
--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -1,3 +1,5 @@
+require 'committee'
+
 module Committee::Rails
   module Test
     module Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'bundler/setup'
 require 'action_controller/railtie'
-require 'committee'
 Bundler.require
 
 require 'fake_app/rails_app'


### PR DESCRIPTION
It fixes an issue that occurs when we set up according to the README.
The `uninitialized constant Committee::Test` was occured.