### PR TITLE
Skip a test that fails when run with committee v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /spec/fake_app/log/
+/gemfiles/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ rvm:
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
+
+gemfile:
+  - gemfiles/committee_2.gemfile
+  - gemfiles/committee_3.gemfile

--- a/gemfiles/committee_2.gemfile
+++ b/gemfiles/committee_2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'committee', '~> 2'
+
+gemspec path: '..'

--- a/gemfiles/committee_3.gemfile
+++ b/gemfiles/committee_3.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'committee', '~> 3'
+
+gemspec path: '..'

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -36,7 +36,9 @@ describe '#assert_schema_conform', type: :request do
       end
     end
 
-    context 'override default setting' do
+    is_committee_v2 = Committee::Test::Methods.method_defined?(:committee_schema)
+    skip_reason = 'this test for 2.4.0, committee 3.x use committee_options'
+    context 'override default setting', skip: (skip_reason unless is_committee_v2) do
       def committee_schema
         @committee_schema ||= Committee::Drivers.load_from_file(Rails.root.join('schema', 'schema.json').to_s)
       end


### PR DESCRIPTION
It updates `.travis.yml` to test against multiple committee versions.
refs: https://docs.travis-ci.com/user/languages/ruby/#testing-against-multiple-versions-of-dependencies
