### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/willnet/committee-rails.svg?branch=master)](https://travis-ci.org/willnet/committee-rails)
 [![Gem Version](https://badge.fury.io/rb/committee-rails.svg)](https://badge.fury.io/rb/committee-rails)
 
-You can use `assert_schema_conform` in rails.
+You can use `assert_response_schema_confirm` in rails.
 
 ## Installation
 
@@ -41,7 +41,7 @@ describe 'request spec' do
   describe 'GET /' do
     it 'conform json schema' do
       get '/'
-      assert_schema_conform
+      assert_response_schema_confirm
     end
   end
 end


### PR DESCRIPTION
Committee will remove method assert_schema_conform in next version, and they deprecated this method.
Now I get this message when I run specs.

```
          [DEPRECATION] now assert_schema_conform check response schema only.
            but we will change check request and response in future major version.
            so if you want to conform response only, please use assert_response_schema_confirm,
            or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
```

Update README and use assert_response_schema_confirm.