### PR TITLE
Update README.md for next version compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ describe 'request spec' do
   include Committee::Rails::Test::Methods
 
   def committee_options
-    @committee_options ||= { schema_path: Rails.root.join('schema', 'schema.json').to_s }
+    @committee_options ||= {
+      schema_path: Rails.root.join('schema', 'schema.json').to_s,
+      query_hash_key: 'rack.request.query_hash',
+    }
   end
 
   describe 'GET /' do
@@ -56,7 +59,10 @@ If you use rspec, you can use very simple.
 ```ruby
 RSpec.configure do |config|
   config.add_setting :committee_options
-  config.committee_options = { schema_path: Rails.root.join('schema', 'schema.json').to_s }
+  config.committee_options = {
+    schema_path: Rails.root.join('schema', 'schema.json').to_s,
+    query_hash_key: 'rack.request.query_hash',
+  }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ describe 'request spec' do
     @committee_options ||= {
       schema_path: Rails.root.join('schema', 'schema.json').to_s,
       query_hash_key: 'rack.request.query_hash',
+      parse_response_by_content_type: false,
     }
   end
 
@@ -62,6 +63,7 @@ RSpec.configure do |config|
   config.committee_options = {
     schema_path: Rails.root.join('schema', 'schema.json').to_s,
     query_hash_key: 'rack.request.query_hash',
+    parse_response_by_content_type: false,
   }
 end
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ describe 'request spec' do
   describe 'GET /' do
     it 'conform json schema' do
       get '/'
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
   end
 end


### PR DESCRIPTION
Latest committee-rails(0.5.1) and latest commitee(4.4.0) with settings described in README.md output these deprecation warnings

```
[DEPRECATION] Committee: please set query_hash_key = rack.request.query_hash because we'll change default value in next major version.
[DEPRECATION] Committee: please set parse_response_by_content_type = false because we'll change default value in next major version.
[DEPRECATION] Pass expected response status code to check it against the corresponding schema explicitly.
```

This PR updates README.md to resolve these deprecation warnings and keep next version compatibility.
(Update details are described in commit messages.) 