### PR TITLE
avoid passing path that contains query string to Committee::Drivers::OpenApi3::Schema#operation_object

### DIFF
--- a/lib/committee/rails/request_object.rb
+++ b/lib/committee/rails/request_object.rb
@@ -9,11 +9,11 @@ module Committee::Rails
     end
 
     def path
-      @request.original_fullpath
+      URI.parse(@request.original_fullpath).path
     end
 
     def path_info
-      @request.original_fullpath
+      URI.parse(@request.original_fullpath).path
     end
 
     def request_method

--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
 end
 
 class UsersController < ApplicationController
+  def index
+    render json: [{ id: 1, nickname: 'willnet' }]
+  end
+
   def create
     render json: { id: 1, nickname: 'willnet' }
   end

--- a/spec/fake_app/schema/schema.yml
+++ b/spec/fake_app/schema/schema.yml
@@ -6,6 +6,32 @@ servers:
 - url: https://example.com/
 paths:
   /users:
+    get:
+      description: read users
+      parameters:
+        - name: page
+          example: 42
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      $ref: '#/components/schemas/id'
+                    nickname:
+                      $ref: '#/components/schemas/nickname'
+                  required:
+                    - id
+                    - nickname
     post:
       description: create user
       requestBody:

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -15,6 +15,13 @@ describe '#assert_schema_conform', type: :request do
         assert_schema_conform(200)
       end
 
+      context 'and request with querystring' do
+        it 'pass' do
+          get '/users', params: { page: 1 }, headers: { 'Content-Type' =>  'application/json' }
+          assert_schema_conform(200)
+        end
+      end
+
       context 'and override #request method' do
         def request
           'hi'


### PR DESCRIPTION
if passing path that contains query stirng to `Committee::Drivers::OpenApi3::Schema#operation_object`, always return nil.
`integration_session.request#path` and `integration_session.request#path_info` returns path without query string.
`RequestObject#path` and `RequestObject#path_info` respect this behavior.