### PR TITLE
Set minimum railties version to match used methods

### DIFF
--- a/committee-rails.gemspec
+++ b/committee-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.add_dependency 'committee', '>= 5.0.0'
-  spec.add_dependency 'activesupport'
-  spec.add_dependency 'actionpack'
-  spec.add_dependency 'railties'
+  spec.add_dependency 'activesupport', '>= 5.1'
+  spec.add_dependency 'actionpack', '>= 5.1'
+  spec.add_dependency 'railties', '>= 5.1'
 end


### PR DESCRIPTION
Hi. I tried to use committee-rails 0.6.1 with a Rails 5.0 application (in a CI pipeline) and it failed with an error message that lead me to writing this PR.

When I tried to figure out what the error message means, I checked the diff between 0.5.0 (which worked a month ago) and 0.6.1 and found that you're using a `delegate_missing_to` method in `lib/committee/rails/request_object.rb`, which was introduced in Rails 5.1.

I quickly checked out the repo, tried to run the test suite with Rails 5.0 and got this (similar what I'm seeing in the original CI)

```
An error occurred while loading ./spec/lib/methods_spec.rb.
Failure/Error: delegate_missing_to :@request

NoMethodError:
  undefined method `delegate_missing_to' for Committee::Rails::RequestObject:Class
  Did you mean?  DelegateClass
# ./lib/committee/rails/request_object.rb:5:in `<class:RequestObject>'
# ./lib/committee/rails/request_object.rb:4:in `<module:Rails>'
# ./lib/committee/rails/request_object.rb:3:in `<top (required)>'
# ./lib/committee/rails/test/methods.rb:2:in `require'
# ./lib/committee/rails/test/methods.rb:2:in `<top (required)>'
# ./lib/committee/rails.rb:2:in `require'
# ./lib/committee/rails.rb:2:in `<top (required)>'
# ./spec/spec_helper.rb:5:in `<top (required)>'

# ./spec/lib/methods_spec.rb:1:in `require'
# ./spec/lib/methods_spec.rb:1:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- committee-rails
#   ./spec/spec_helper.rb:5:in `<top (required)>'
```

As Rails 5.0 is not maintained anymore, I think the best is to drop the support here.