### PR TITLE
Add secret_key_base to test FakeApp to pass the tests with Rails 5.1

### DIFF
--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -3,6 +3,7 @@ FakeApp.config.session_store :cookie_store, key: '_myapp_session'
 FakeApp.config.eager_load = false
 FakeApp.config.hosts << 'www.example.com' if FakeApp.config.respond_to?(:hosts)
 FakeApp.config.root = File.dirname(__FILE__)
+FakeApp.config.secret_key_base = 'secret'
 FakeApp.initialize!
 
 FakeApp.routes.draw do


### PR DESCRIPTION
Hi. As I mentioned in https://github.com/willnet/committee-rails/pull/19#issuecomment-1207801818 I had some issues running the specs with Rails 5.1. There were 8 failing specs for me, the error messages all looked like this:

```
Failure/Error: post '/users', params: { nickname: 'willnet' }.to_json, headers: { 'Content-Type' =>
'application/json' }

     RuntimeError:
       Missing `secret_key_base` for 'development' environment, set this value in `config/secrets.yml`
     # ./spec/lib/methods_spec.rb:14:in `block (4 levels) in <top (required)>'
```

I quickly added the secret_key_base to the FakeApp and it's working again!