### PR TITLE
Add Ruby 3.2 supported by CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
           - 'head'
         include:
           - ruby: 'head'


### PR DESCRIPTION
This PR is add Ruby 3.2 supported by CI.

Refs:
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/