### PR TITLE
Drop support ruby 2.4, 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.4'
-          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'


### PR DESCRIPTION
committee 5.0 supports >= Ruby 2.6
