### PR TITLE
Bump committee >= 5.0.0

### DIFF
--- a/committee-rails.gemspec
+++ b/committee-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_dependency 'committee', '>= 4.4.0'
+  spec.add_dependency 'committee', '>= 5.0.0'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'actionpack'
   spec.add_dependency 'railties'

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -6,7 +6,7 @@ describe '#assert_schema_conform', type: :request do
   context 'when set option' do
     before do
       RSpec.configuration.add_setting :committee_options
-      RSpec.configuration.committee_options = { schema_path: Rails.root.join('schema', 'schema.yml').to_s, old_assert_behavior: false, query_hash_key: 'rack.request.query_hash', parse_response_by_content_type: false }
+      RSpec.configuration.committee_options = { schema_path: Rails.root.join('schema', 'schema.yml').to_s, old_assert_behavior: false, query_hash_key: 'rack.request.query_hash', parse_response_by_content_type: false, strict_reference_validation: true }
     end
 
     context 'and when response conform YAML Schema' do


### PR DESCRIPTION
Add `strict_reference_validation: true` to commitee_options in test to supress following warnings from committee 5.0.0

```
[DEPRECATION] openapi_parser will default to strict reference validation from next version. Pass config `strict_reference_validation: true` (or false, if you must) to quiet this warning.
```
