### PR TITLE
Add example about assert_schema_conform method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/willnet/committee-rails/actions/workflows/test.yml/badge.svg)](https://github.com/willnet/committee-rails/actions/workflows/test.yml)
 [![Gem Version](https://badge.fury.io/rb/committee-rails.svg)](https://badge.fury.io/rb/committee-rails)
 
-You can use `assert_response_schema_confirm` in rails.
+You can use `assert_response_schema_confirm` or `assert_schema_conform` in rails.
 
 ## Looking for maintainers!
 
@@ -61,6 +61,11 @@ describe 'request spec' do
     it 'conform json schema' do
       get '/'
       assert_response_schema_confirm(200)
+    end
+
+    it 'conform json schema request and response' do
+      get '/'
+      assert_schema_conform(200)
     end
   end
 end


### PR DESCRIPTION
Hi, all!

It seems that in committee 5.0.0, the `old_assert_behavior` became false by default, and `assert_schema_conform` is no longer experimental. It might be better to describe `assert_schema_conform` in committee-rails README. 

- https://github.com/interagent/committee/blob/master/CHANGELOG.md#500beta1---2023-01-25:~:text=Change%20old%20assert%20behavior%20%23380
- https://github.com/interagent/committee/pull/380