### PR TITLE
Fix some deprecation warning

### DIFF
--- a/lib/committee/rails/test/methods.rb
+++ b/lib/committee/rails/test/methods.rb
@@ -10,7 +10,7 @@ module Committee::Rails
         if defined?(RSpec) && (options = RSpec.try(:configuration).try(:committee_options))
           options
         else
-          { schema_path: default_schema }
+          { schema_path: default_schema, strict_reference_validation: false }
         end
       end
 

--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -4,6 +4,7 @@ FakeApp.config.eager_load = false
 FakeApp.config.hosts << 'www.example.com' if FakeApp.config.respond_to?(:hosts)
 FakeApp.config.root = File.dirname(__FILE__)
 FakeApp.config.secret_key_base = 'secret'
+FakeApp.config.active_support.cache_format_version = 7.0
 FakeApp.initialize!
 
 FakeApp.routes.draw do

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -6,7 +6,7 @@ describe '#assert_schema_conform', type: :request do
   context 'when set option' do
     before do
       RSpec.configuration.add_setting :committee_options
-      RSpec.configuration.committee_options = { schema_path: Rails.root.join('schema', 'schema.yml').to_s, old_assert_behavior: false, query_hash_key: 'rack.request.query_hash', parse_response_by_content_type: false, strict_reference_validation: true }
+      RSpec.configuration.committee_options = { schema_path: Rails.root.join('schema', 'schema.yml').to_s, old_assert_behavior: false, query_hash_key: 'rack.request.query_hash', parse_response_by_content_type: false }
     end
 
     context 'and when response conform YAML Schema' do
@@ -87,7 +87,7 @@ describe '#assert_schema_conform', type: :request do
 
     context 'when override default setting' do
       def committee_options
-        { schema_path: Rails.root.join('schema', 'schema.yml').to_s, old_assert_behavior: false, query_hash_key: 'rack.request.query_hash', parse_response_by_content_type: false }
+        { schema_path: Rails.root.join('schema', 'schema.yml').to_s, old_assert_behavior: false, query_hash_key: 'rack.request.query_hash', parse_response_by_content_type: false, strict_reference_validation: true}
       end
 
       it 'use the setting' do

--- a/spec/lib/methods_spec.rb
+++ b/spec/lib/methods_spec.rb
@@ -57,7 +57,7 @@ describe '#assert_schema_conform', type: :request do
         original_show_detailed_exceptions = Rails.application.env_config['action_dispatch.show_detailed_exceptions']
         original_show_exceptions = Rails.application.env_config['action_dispatch.show_exceptions']
         Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = false
-        Rails.application.env_config['action_dispatch.show_exceptions'] = true
+        Rails.application.env_config['action_dispatch.show_exceptions'] = :all
         begin
           example.run
         ensure


### PR DESCRIPTION
- Fix a deprecation warning for `config.active_support.cache_format_version = 6.1`:  https://github.com/willnet/committee-rails/commit/1c8b4db135a70f56d60b986647646a73a8184222
- Fix a deprecation warning for `action_dispatch.show_exceptions to true`:  https://github.com/willnet/committee-rails/commit/1cff29cb58f98e84e020a09e40b3000e04972872
- Fix a deprecation warning for `strict_reference_validation`: https://github.com/willnet/committee-rails/commit/453fe3db10755114f1c784fa7c0b1d8e8d4886e7

```
❯ bundle exec rake
/ydah/.rbenv/versions/3.1.2/bin/ruby -I/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.2/lib:/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-support-3.12.1/lib /ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from <top (required)> at /ydah/committee-rails/spec/fake_app/rails_app.rb:7)
.....DEPRECATION WARNING: Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead. (called from block (4 levels) in <top (required)> at /ydah/committee-rails/spec/lib/methods_spec.rb:70)
DEPRECATION WARNING: Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead. (called from block (4 levels) in <top (required)> at /ydah/committee-rails/spec/lib/methods_spec.rb:70)
..[DEPRECATION] openapi_parser will default to strict reference validation from next version. Pass config `strict_reference_validation: true` (or false, if you must) to quiet this warning.
.

Finished in 0.08263 seconds (files took 1.63 seconds to load)
8 examples, 0 failures
```
