### PR TITLE
Change the README example to a simple because the warning no longer appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,7 @@ describe 'request spec' do
   include Committee::Rails::Test::Methods
 
   def committee_options
-    @committee_options ||= {
-      schema_path: Rails.root.join('schema', 'schema.json').to_s,
-      query_hash_key: 'rack.request.query_hash',
-      parse_response_by_content_type: false,
-    }
+    @committee_options ||= { schema_path: Rails.root.join('schema', 'schema.json').to_s }
   end
 
   describe 'GET /' do
@@ -82,11 +78,7 @@ If you use rspec, you can use very simple.
 ```ruby
 RSpec.configure do |config|
   config.add_setting :committee_options
-  config.committee_options = {
-    schema_path: Rails.root.join('schema', 'schema.json').to_s,
-    query_hash_key: 'rack.request.query_hash',
-    parse_response_by_content_type: false,
-  }
+  config.committee_options = { schema_path: Rails.root.join('schema', 'schema.json').to_s }
 end
 ```
 


### PR DESCRIPTION
Since the latest committee version (5.0.0) no longer produces deprecation warnings, how about reverting to the original simple configuration?
- https://github.com/willnet/committee-rails/pull/12