### PR TITLE
Bump committee from 5.0.0 to 5.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/committee-rails.gemspec
+++ b/committee-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.add_dependency 'committee', '>= 5.1.0'
-  spec.add_dependency 'activesupport', '>= 5.1'
-  spec.add_dependency 'actionpack', '>= 5.1'
-  spec.add_dependency 'railties', '>= 5.1'
+  spec.add_dependency 'activesupport', '>= 6.0'
+  spec.add_dependency 'actionpack', '>= 6.0'
+  spec.add_dependency 'railties', '>= 6.0'
 end

--- a/committee-rails.gemspec
+++ b/committee-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_dependency 'committee', '>= 5.0.0'
+  spec.add_dependency 'committee', '>= 5.1.0'
   spec.add_dependency 'activesupport', '>= 5.1'
   spec.add_dependency 'actionpack', '>= 5.1'
   spec.add_dependency 'railties', '>= 5.1'


### PR DESCRIPTION
This PR bump committee from 5.0.0 to 5.1.0.
And drop support for Ruby 2.6.

committee (5.1.0) drops support for Ruby 2.6.
- https://github.com/interagent/committee/blob/master/CHANGELOG.md

And bump activesupport, actionpack and railties from 5.1 to 6.0