### PR TITLE
Add Ruby 3.4 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - 'head'
         include:
           - ruby: 'head'


### PR DESCRIPTION
This PR adds Ruby 3.4 to CI matrix

Ruby 3.4 has been released
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/